### PR TITLE
Add support for any profile. Resolves #24.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Connect to home or work wireless networks, caching rolling passwords at work
 Optional arguments:
   -s, show [index|today|tomorrow]	display the daily password of the given index or day
   -r, restart [profile]			restarts the given profile
+  -p, profile [profile]			connects to any profile under netctl
+  -u, update				update profiles under netctl
   -h, --help				display this help and exit
 
 chwifi is released under GPL-2.0 and comes with ABSOLUTELY NO WARRANTY, for details read LICENSE
@@ -64,6 +66,12 @@ To connect to work with cached password, pass argument `work`.
 chwifi work
 ```
 
+To connect to a given profile under netctl, pass either `-p` or `profile` followed by the profile-name.
+```shell
+chwifi -p profile-name
+chwifi profile profile-name
+```
+
 To show a specific password pass '-s' or 'show' followed by an index, e.g., where 1 is tomorrow's password. Using the keywords 'today' and 'tomorrow' is also supported.
 ```shell
 chwifi -s 3
@@ -74,6 +82,12 @@ To restart a given profile, pass either `-r` or `restart` followed by the profil
 ```shell
 chwifi -r home
 chwifi restart work
+```
+
+To update recognised profiles, pass either `-u` or `update`
+```shell
+chwifi -u
+chwifi update
 ```
 
 ## Configuration
@@ -101,6 +115,7 @@ network_manager_stopall="stop-all"
 network_manager_restart="restart"
 network_manager_home_profile="home"
 network_manager_work_profile="work"
+network_manager_other_profiles="other-profiles"
 ```
 
 Options for macchanger, default is enabled which is set during setup and is either `y` or `n`, `-e` is the default option, which randomises only device-specific bytes and retains vendor-information.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ chwifi -r home
 chwifi restart work
 ```
 
-To update recognised profiles, pass either `-u` or `update`
+To update recognised profiles, pass either `-u` or `update`.
 ```shell
 chwifi -u
 chwifi update
@@ -115,7 +115,7 @@ network_manager_stopall="stop-all"
 network_manager_restart="restart"
 network_manager_home_profile="home"
 network_manager_work_profile="work"
-network_manager_other_profiles="other-profiles"
+network_manager_other_profiles="a-profile,another-profile,last-profile"
 ```
 
 Options for macchanger, default is enabled which is set during setup and is either `y` or `n`, `-e` is the default option, which randomises only device-specific bytes and retains vendor-information.

--- a/chwifi
+++ b/chwifi
@@ -85,6 +85,33 @@ update_routine() {
     fi
 }
 
+update_profiles() {
+    printf '%s\n' "Updating profiles..."
+    profiles=""
+    # Grab other profiles and concatenate in string, using semicolon as seperator
+    for entry in "/etc/netctl"/*; do
+        if [ -f "$entry" ]; then
+            profiles+=$(echo "$entry" | sed -e 's/\/etc\/netctl\///g')';'
+        fi
+    done
+    # Remove final semicolon from string
+    profiles=${profiles::-1}
+    # Regex other profiles into config
+    sed -i "s/\"$network_manager_other_profiles\"$/\"$profiles\"/" "$XDG_CONFIG_HOME/config"
+}
+
+check_profile() {
+    IFS=';'
+    read -r -a profiles <<< "$network_manager_other_profiles"
+    IFS=' '
+    for x in "${profiles[@]}"; do
+        if [ "$x" == "$1" ] ; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 # Change MAC-address according to sourced options and print new MAC-address
 change_mac() {
     printf "New MAC-address: "
@@ -198,6 +225,19 @@ while (( "$#" )); do
         home|work) 
             profile=$1
             # Shift remaining arguments off stack
+            break
+            ;;
+        -p|profile)
+            if check_profile "$2" ; then
+                profile=$2
+            else
+                err_input=1
+            fi
+            break
+            ;;
+        -u|update)
+            # Update other profiles
+            update_profiles
             break
             ;;
         *)

--- a/chwifi
+++ b/chwifi
@@ -92,7 +92,7 @@ update_profiles() {
     # Grab other profiles and concatenate in string, using comma as delimiter
     for entry in "/etc/netctl"/*; do
         if [ -f "$entry" ]; then
-            profiles+=$(echo "$entry" | sed -e 's/\/etc\/netctl\///g')','
+            profiles+=$(echo "$(basename $entry)")','
         fi
     done
     # Remove final comma from string

--- a/chwifi
+++ b/chwifi
@@ -102,9 +102,12 @@ update_profiles() {
 }
 
 check_profile() {
+    # Set internal field separator and read other profiles to array
     IFS=','
     read -r -a profiles <<< "$network_manager_other_profiles"
+    # Reset internal field separator to default value
     IFS=' '
+    # Check user input against profile array, return true if match is found, otherwise false
     for x in "${profiles[@]}"; do
         if [ "$x" == "$1" ] ; then
             return 0

--- a/chwifi
+++ b/chwifi
@@ -109,6 +109,7 @@ check_profile() {
     IFS=' '
     # Check user input against profile array, return true if match is found, otherwise false
     for x in "${profiles[@]}"; do
+        # Strip leading and trailing white spaces, in case the user manually input other profiles and included these
         x=$(echo "$x" | sed -e 's/^\s*//g')
         x=$(echo "$x" | sed -e 's/\s*$//g')
         if [ "$x" == "$1" ] ; then

--- a/chwifi
+++ b/chwifi
@@ -109,6 +109,8 @@ check_profile() {
     IFS=' '
     # Check user input against profile array, return true if match is found, otherwise false
     for x in "${profiles[@]}"; do
+        x=$(echo "$x" | sed -e 's/^\s*//g')
+        x=$(echo "$x" | sed -e 's/\s*$//g')
         if [ "$x" == "$1" ] ; then
             return 0
         fi

--- a/chwifi
+++ b/chwifi
@@ -89,13 +89,13 @@ update_profiles() {
     printf '%s\n' "Updating profiles..."
     config=$(config_dir)
     profiles=""
-    # Grab other profiles and concatenate in string, using semicolon as seperator
+    # Grab other profiles and concatenate in string, using comma as delimiter
     for entry in "/etc/netctl"/*; do
         if [ -f "$entry" ]; then
             profiles+=$(echo "$entry" | sed -e 's/\/etc\/netctl\///g')','
         fi
     done
-    # Remove final semicolon from string
+    # Remove final comma from string
     profiles=${profiles::-1}
     # Regex other profiles into config
     sed -i "s/\"$network_manager_other_profiles\"$/\"$profiles\"/" "$config/config"

--- a/chwifi
+++ b/chwifi
@@ -170,6 +170,8 @@ display_help() {
     printf "Optional arguments:\n"
     printf "  -s, show [index|today|tomorrow]\tdisplay the daily password of the given index or day\n"
     printf "  -r, restart [profile]\t\t\trestarts the given profile\n"
+    printf "  -p, profile [profile]\t\t\tconnects to any profile under netctl\n"
+    printf "  -u, update\t\t\t\tupdate profiles under netctl\n"
     printf "  -h, --help\t\t\t\tdisplay this help and exit\n\n"
     printf "chwifi is released under GPL-2.0 and comes with ABSOLUTELY NO WARRANTY, for details read LICENSE\n"
     printf "Configuration of this script is done through the 'config' file, for documentation read README.md\n"

--- a/chwifi
+++ b/chwifi
@@ -92,7 +92,7 @@ update_profiles() {
     # Grab other profiles and concatenate in string, using semicolon as seperator
     for entry in "/etc/netctl"/*; do
         if [ -f "$entry" ]; then
-            profiles+=$(echo "$entry" | sed -e 's/\/etc\/netctl\///g')';'
+            profiles+=$(echo "$entry" | sed -e 's/\/etc\/netctl\///g')','
         fi
     done
     # Remove final semicolon from string
@@ -102,7 +102,7 @@ update_profiles() {
 }
 
 check_profile() {
-    IFS=';'
+    IFS=','
     read -r -a profiles <<< "$network_manager_other_profiles"
     IFS=' '
     for x in "${profiles[@]}"; do

--- a/chwifi
+++ b/chwifi
@@ -87,6 +87,7 @@ update_routine() {
 
 update_profiles() {
     printf '%s\n' "Updating profiles..."
+    config=$(config_dir)
     profiles=""
     # Grab other profiles and concatenate in string, using semicolon as seperator
     for entry in "/etc/netctl"/*; do
@@ -97,7 +98,7 @@ update_profiles() {
     # Remove final semicolon from string
     profiles=${profiles::-1}
     # Regex other profiles into config
-    sed -i "s/\"$network_manager_other_profiles\"$/\"$profiles\"/" "$XDG_CONFIG_HOME/config"
+    sed -i "s/\"$network_manager_other_profiles\"$/\"$profiles\"/" "$config/config"
 }
 
 check_profile() {
@@ -153,7 +154,10 @@ connect_dispatch() {
         
         # Change work profile password and do connection routine
         change_profile_password "$network_manager_work_profile" "$daily_password"
-        connection_routine "$network_manager_work_profile" 
+        connection_routine "$network_manager_work_profile"
+    elif check_profile "$1" ; then
+        printf '%s\n' "Connecting to $1"
+        connection_routine "$1"
     else
         printf "An error occured while connecting to: '%s', please check" "$1"
         exit 1
@@ -228,11 +232,7 @@ while (( "$#" )); do
             break
             ;;
         -p|profile)
-            if check_profile "$2" ; then
-                profile=$2
-            else
-                err_input=1
-            fi
+            profile=$2
             break
             ;;
         -u|update)

--- a/config.sample
+++ b/config.sample
@@ -25,7 +25,7 @@ network_manager_stopall="stop-all"
 network_manager_restart="restart"
 network_manager_home_profile="home"
 network_manager_work_profile="work"
-network_manager_other_profiles="other-profiles"
+network_manager_other_profiles="a-profile,another-profile,last-profile"
 
 # Options for macchanger, -e, which randomises only device-specific bytes.
 macchanger_enabled="$MAC_ENABLED"

--- a/config.sample
+++ b/config.sample
@@ -25,6 +25,7 @@ network_manager_stopall="stop-all"
 network_manager_restart="restart"
 network_manager_home_profile="home"
 network_manager_work_profile="work"
+network_manager_other_profiles="other-profiles"
 
 # Options for macchanger, -e, which randomises only device-specific bytes.
 macchanger_enabled="$MAC_ENABLED"

--- a/setup.sh
+++ b/setup.sh
@@ -39,6 +39,16 @@ setup() {
         mac_enable="${mac_enable:-y}"
         printf "\nReceived username: %s and macchanger: %s.\nCreating config at %s/config\n" "$username" "$mac_enable" "$config"
 
+        profiles=""
+        # Grab other profiles and concatenate in string, using semicolon as seperator
+        for entry in "/etc/netctl"/*; do
+            if [ -f "$entry" ]; then
+                profiles+=$(echo "$entry" | sed -e 's/\/etc\/netctl\///g')';'
+            fi
+        done
+        # Remove final semicolon from string
+        profiles=${profiles::-1}
+
         # Copy config.sample into dir
         cp /usr/lib/chwifi/config.sample "$config/config"
         # Regex username and password into config
@@ -48,6 +58,8 @@ setup() {
         sed -i "s|\$MAC_ENABLED|$mac_enable|" "$config/config"
         # Regex config directory, using pipe for separator
         sed -i "s|\$XDG_CONFIG_HOME|$config|" "$config/config"
+        # Regex other profiles into config
+        sed -i "s/\"other-profiles\"$/\"$profiles\"/" "$config/config"
         
         if [ -f "$config/config" ]; then
             printf "Successfully created config at: %s/config\n\n" "$config"

--- a/setup.sh
+++ b/setup.sh
@@ -46,7 +46,7 @@ setup() {
                 profiles+=$(echo "$entry" | sed -e 's/\/etc\/netctl\///g')','
             fi
         done
-        # Remove final semicolon from string
+        # Remove final comma from string
         profiles=${profiles::-1}
 
         # Copy config.sample into dir

--- a/setup.sh
+++ b/setup.sh
@@ -40,10 +40,10 @@ setup() {
         printf "\nReceived username: %s and macchanger: %s.\nCreating config at %s/config\n" "$username" "$mac_enable" "$config"
 
         profiles=""
-        # Grab other profiles and concatenate in string, using semicolon as seperator
+        # Grab other profiles and concatenate in string, using comma as delimiter
         for entry in "/etc/netctl"/*; do
             if [ -f "$entry" ]; then
-                profiles+=$(echo "$entry" | sed -e 's/\/etc\/netctl\///g')';'
+                profiles+=$(echo "$entry" | sed -e 's/\/etc\/netctl\///g')','
             fi
         done
         # Remove final semicolon from string

--- a/setup.sh
+++ b/setup.sh
@@ -43,7 +43,7 @@ setup() {
         # Grab other profiles and concatenate in string, using comma as delimiter
         for entry in "/etc/netctl"/*; do
             if [ -f "$entry" ]; then
-                profiles+=$(echo "$entry" | sed -e 's/\/etc\/netctl\///g')','
+                profiles+=$(echo "$(basename $entry)")','
             fi
         done
         # Remove final comma from string

--- a/setup.sh
+++ b/setup.sh
@@ -59,7 +59,7 @@ setup() {
         # Regex config directory, using pipe for separator
         sed -i "s|\$XDG_CONFIG_HOME|$config|" "$config/config"
         # Regex other profiles into config
-        sed -i "s/\"other-profiles\"$/\"$profiles\"/" "$config/config"
+        sed -i "s/\"a-profile,another-profile,last-profile\"$/\"$profiles\"/" "$config/config"
         
         if [ -f "$config/config" ]; then
             printf "Successfully created config at: %s/config\n\n" "$config"


### PR DESCRIPTION
- Added `[-p|profile] <profile>` option that allows switching to any profile under netctl. All netctl profiles are added to config file during first-time setup.
- Added `[-u|update]` option that updates netctl profiles in config file.
- Updated `-h` text to reflect new options.
- Updated README to reflect new usages, and change in config file.