### PR TITLE
Simplify passing any profile as argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A help message is displayed when passing no arguments, `-h`, or `--help`.
 ```
 user@hostname ~> chwifi
 Usage: chwifi [OPTION]... <PROFILE>
-Connect any network-manager wireless networks, caching rolling passwords at work
+Connect to any netctl wireless networks, caching rolling passwords at work
 
 Optional arguments:
   -s, show [index|today|tomorrow]	display the daily password of the given index or day

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 # chwifi
-This tool automates network-switching for users who connect wirelessly at home and at a workplace employing a rolling-password model for their wireless networks by automatically configuring network profiles according to locally cached passwords. Device-specific bytes of MAC-address are randomised during each connection routine. 
+This tool automates network-switching for users who connect wirelessly a workplace employing a rolling-password model for their wireless networks by automatically configuring network profiles according to locally cached passwords. Device-specific bytes of MAC-address are randomised during each connection routine. Furthermore, connecting to any other network profile is supported.
 
 Through scripting CAS-login, downloading currently available passwords, caching them locally, and matching daily password with given date, automatic network-manager profile configuration is achieved for following days specified by service. 
 In the case of Aalborg University; if chwifi has been invoked within the previous three days, the current daily password will be cached and available for automatic configuration, thus ensuring no manual input for consecutive five-day workweeks.
@@ -43,12 +43,11 @@ A help message is displayed when passing no arguments, `-h`, or `--help`.
 ```
 user@hostname ~> chwifi
 Usage: chwifi [OPTION]... <PROFILE>
-Connect to home or work wireless networks, caching rolling passwords at work
+Connect any network-manager wireless networks, caching rolling passwords at work
 
 Optional arguments:
   -s, show [index|today|tomorrow]	display the daily password of the given index or day
   -r, restart [profile]			restarts the given profile
-  -p, profile [profile]			connects to any profile under netctl
   -u, update				update profiles under netctl
   -h, --help				display this help and exit
 
@@ -56,20 +55,11 @@ chwifi is released under GPL-2.0 and comes with ABSOLUTELY NO WARRANTY, for deta
 Configuration of this script is done through the 'config' file, for documentation read README.md
 ```
 
-To connect to home, pass argument `home`.
+To connect to a given profile under netctl, pass its' name as an argument.
 ```shell
 chwifi home
-```
-
-To connect to work with cached password, pass argument `work`.
-```shell
 chwifi work
-```
-
-To connect to a given profile under netctl, pass either `-p` or `profile` followed by the profile-name.
-```shell
-chwifi -p profile-name
-chwifi profile profile-name
+chwifi profile-name
 ```
 
 To show a specific password pass '-s' or 'show' followed by an index, e.g., where 1 is tomorrow's password. Using the keywords 'today' and 'tomorrow' is also supported.
@@ -84,7 +74,7 @@ chwifi -r home
 chwifi restart work
 ```
 
-To update recognised profiles, pass either `-u` or `update`.
+To update recognised profiles, pass either `-u` or `update`. This should be done whenever a profile is added or removed from the network-manager.
 ```shell
 chwifi -u
 chwifi update

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ chwifi -r home
 chwifi restart work
 ```
 
-To update recognised profiles, pass either `-u` or `update`. This should be done whenever a profile is added or removed from the network-manager.
+To update recognised profiles, pass either `-u` or `update`. This should be done whenever a profile is added or removed.
 ```shell
 chwifi -u
 chwifi update

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </p>
 
 # chwifi
-This tool automates network-switching for users who connect wirelessly a workplace employing a rolling-password model for their wireless networks by automatically configuring network profiles according to locally cached passwords. Device-specific bytes of MAC-address are randomised during each connection routine. Furthermore, connecting to any other network profile is supported.
+This tool automates network-switching for users who connect wirelessly at a workplace employing a rolling-password model for their wireless networks by automatically configuring network profiles according to locally cached passwords. Device-specific bytes of MAC-address are randomised during each connection routine. Furthermore, connecting to any other network profile is supported.
 
 Through scripting CAS-login, downloading currently available passwords, caching them locally, and matching daily password with given date, automatic network-manager profile configuration is achieved for following days specified by service. 
 In the case of Aalborg University; if chwifi has been invoked within the previous three days, the current daily password will be cached and available for automatic configuration, thus ensuring no manual input for consecutive five-day workweeks.

--- a/chwifi
+++ b/chwifi
@@ -157,6 +157,7 @@ connect_dispatch() {
         change_profile_password "$network_manager_work_profile" "$daily_password"
         connection_routine "$network_manager_work_profile"
     else
+        # If not work, simply connect to given profile
         printf '%s\n' "Connecting to $1"
         connection_routine "$1"
     fi 
@@ -164,11 +165,10 @@ connect_dispatch() {
 
 display_help() {
     printf "Usage: chwifi [OPTION]... <PROFILE>\n"
-    printf "Connect to home or work wireless networks, caching rolling passwords at work\n\n"
+    printf "Connect any network-manager wireless networks, caching rolling passwords at work\n\n"
     printf "Optional arguments:\n"
     printf "  -s, show [index|today|tomorrow]\tdisplay the daily password of the given index or day\n"
     printf "  -r, restart [profile]\t\t\trestarts the given profile\n"
-    printf "  -p, profile [profile]\t\t\tconnects to any profile under netctl\n"
     printf "  -u, update\t\t\t\tupdate profiles under netctl\n"
     printf "  -h, --help\t\t\t\tdisplay this help and exit\n\n"
     printf "chwifi is released under GPL-2.0 and comes with ABSOLUTELY NO WARRANTY, for details read LICENSE\n"
@@ -232,6 +232,7 @@ while (( "$#" )); do
             break
             ;;
         *)
+            # If an unrecognized argument is given, check if it is a recognized netctl profile
             if check_profile "$1" ; then
                 profile=$1
             else

--- a/chwifi
+++ b/chwifi
@@ -139,7 +139,7 @@ display_daily_password() {
 
 connect_dispatch() {
     # If work, then find password, connect and update cached passwords when connection is given
-    if [[ "$1" =~ work ]]; then
+    if [[ "$1" =~ $network_manager_work_profile ]]; then
         printf '%s\n' "Connecting to work, checking for cached password"
         # Grab daily password from helper
         daily_password=$(get_daily_password)

--- a/chwifi
+++ b/chwifi
@@ -91,7 +91,7 @@ update_profiles() {
     profiles=""
     # Grab other profiles and concatenate in string, using comma as delimiter
     for entry in "/etc/netctl"/*; do
-        if [ -f "$entry" ] && [[ ! "$entry" =~ work ]] ; then
+        if [ -f "$entry" ] && [[ ! "$entry" =~ ^work$ ]] ; then
             profiles+=$(echo "$(basename $entry)")','
         fi
     done

--- a/chwifi
+++ b/chwifi
@@ -91,7 +91,7 @@ update_profiles() {
     profiles=""
     # Grab other profiles and concatenate in string, using comma as delimiter
     for entry in "/etc/netctl"/*; do
-        if [ -f "$entry" ] && [[ ! "$entry" =~ ^work$ ]] ; then
+        if [ -f "$entry" ] && [[ ! "$entry" =~ ^$work$ ]] ; then
             profiles+=$(echo "$(basename $entry)")','
         fi
     done

--- a/chwifi
+++ b/chwifi
@@ -91,7 +91,7 @@ update_profiles() {
     profiles=""
     # Grab other profiles and concatenate in string, using comma as delimiter
     for entry in "/etc/netctl"/*; do
-        if [ -f "$entry" ] && [[ ! "$entry" =~ ^$work$ ]] ; then
+        if [ -f "$entry" ] && [[ ! "$entry" =~ ^$network_manager_work_profile$ ]] ; then
             profiles+=$(echo "$(basename $entry)")','
         fi
     done

--- a/chwifi
+++ b/chwifi
@@ -76,7 +76,7 @@ wait_for_network() {
 update_routine() {
     printf '%s\n' "Waiting for network connection..."
     wait_for_network
-    printf '%s\n' "Network connection established, updating cached passwords" 
+    printf '%s\n' "Network connection established, updating cached passwords"
     update_passwords
     if [[ $? -eq 0 ]]; then
         printf "Successfully updated cached passwords\n"
@@ -138,13 +138,8 @@ display_daily_password() {
 }
 
 connect_dispatch() {
-    # If home, then connect and update cached passwords when connection is given
-    if [[ "$1" =~ home ]]; then
-        printf '%s\n' "Connecting to home"
-        connection_routine "$network_manager_home_profile"
-        
     # If work, then find password, connect and update cached passwords when connection is given
-    elif [[ "$1" =~ work ]]; then
+    if [[ "$1" =~ work ]]; then
         printf '%s\n' "Connecting to work, checking for cached password"
         # Grab daily password from helper
         daily_password=$(get_daily_password)
@@ -161,12 +156,9 @@ connect_dispatch() {
         # Change work profile password and do connection routine
         change_profile_password "$network_manager_work_profile" "$daily_password"
         connection_routine "$network_manager_work_profile"
-    elif check_profile "$1" ; then
+    else
         printf '%s\n' "Connecting to $1"
         connection_routine "$1"
-    else
-        printf "An error occured while connecting to: '%s', please check" "$1"
-        exit 1
     fi 
 }
 
@@ -234,23 +226,18 @@ while (( "$#" )); do
             display_help
             exit 0
             ;;
-        home|work) 
-            profile=$1
-            # Shift remaining arguments off stack
-            break
-            ;;
-        -p|profile)
-            profile=$2
-            break
-            ;;
         -u|update)
             # Update other profiles
             update_profiles
             break
             ;;
         *)
-            # Unknown parameter, register error and break
-            err_input=1
+            if check_profile "$1" ; then
+                profile=$1
+            else
+                # Unknown parameter, register error and break
+                err_input=1
+            fi
             break
             ;;
     esac

--- a/chwifi
+++ b/chwifi
@@ -91,7 +91,7 @@ update_profiles() {
     profiles=""
     # Grab other profiles and concatenate in string, using comma as delimiter
     for entry in "/etc/netctl"/*; do
-        if [ -f "$entry" ]; then
+        if [ -f "$entry" ] && [[ ! "$entry" =~ work ]] ; then
             profiles+=$(echo "$(basename $entry)")','
         fi
     done

--- a/chwifi
+++ b/chwifi
@@ -139,7 +139,7 @@ display_daily_password() {
 
 connect_dispatch() {
     # If work, then find password, connect and update cached passwords when connection is given
-    if [[ "$1" =~ $network_manager_work_profile ]]; then
+    if [[ "$1" =~ ^$network_manager_work_profile$ ]]; then
         printf '%s\n' "Connecting to work, checking for cached password"
         # Grab daily password from helper
         daily_password=$(get_daily_password)

--- a/chwifi
+++ b/chwifi
@@ -165,7 +165,7 @@ connect_dispatch() {
 
 display_help() {
     printf "Usage: chwifi [OPTION]... <PROFILE>\n"
-    printf "Connect any network-manager wireless networks, caching rolling passwords at work\n\n"
+    printf "Connect to any netctl wireless networks, caching rolling passwords at work\n\n"
     printf "Optional arguments:\n"
     printf "  -s, show [index|today|tomorrow]\tdisplay the daily password of the given index or day\n"
     printf "  -r, restart [profile]\t\t\trestarts the given profile\n"

--- a/config.sample
+++ b/config.sample
@@ -24,7 +24,7 @@ network_manager_disconnect="stop"
 network_manager_stopall="stop-all"
 network_manager_restart="restart"
 network_manager_home_profile="home"
-network_manager_work_profile="work"
+network_manager_work_profile="work-profile"
 network_manager_other_profiles="a-profile,another-profile,last-profile"
 
 # Options for macchanger, -e, which randomises only device-specific bytes.

--- a/setup.sh
+++ b/setup.sh
@@ -22,6 +22,12 @@ setup() {
         read -r username
         printf "Please input password:\n"
         read -r -s password
+
+        default_work_profile='work'
+        printf "Please input name of work profile[%s]:\n" "$default_work_profile"
+        read -r work_profile
+        work_profile=${work_profile:-$default_work_profile}
+
         printf "Enable macchanger to randomise MAC-address upon each connection? [Y/n]: "
         read -r mac_enable
 
@@ -54,6 +60,8 @@ setup() {
         # Regex username and password into config
         sed -i "s/\"username\"$/\"$username\"/" "$config/config"
         sed -i "s/\"password\"$/\"$password\"/" "$config/config"
+        # Regex work profile name into config
+        sed -i "s/\"work-profile\"$/\"$work_profile\"/" "$config/config"
         # Regex macchanger boolean into config
         sed -i "s|\$MAC_ENABLED|$mac_enable|" "$config/config"
         # Regex config directory, using pipe for separator

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ setup() {
         read -r -s password
 
         default_profile='work'
-        printf "Please input name of work profile[%s]:\n" "$default_profile"
+        printf "Please input the name of the work profile[%s]:\n" "$default_profile"
         read -r profile_input
         profile_input=${profile_input:-$default_profile}
 

--- a/setup.sh
+++ b/setup.sh
@@ -48,7 +48,7 @@ setup() {
         profiles=""
         # Grab other profiles and concatenate in string, using comma as delimiter
         for entry in "/etc/netctl"/*; do
-            if [ -f "$entry" ] && [[ ! "$entry" =~ ^work$ ]] ; then
+            if [ -f "$entry" ] && [[ ! "$entry" =~ ^$work_profile$ ]] ; then
                 profiles+=$(echo "$(basename $entry)")','
             fi
         done

--- a/setup.sh
+++ b/setup.sh
@@ -23,10 +23,10 @@ setup() {
         printf "Please input password:\n"
         read -r -s password
 
-        default_profile='work'
-        printf "Please input the name of the work profile[%s]:\n" "$default_profile"
-        read -r profile_input
-        profile_input=${profile_input:-$default_profile}
+        default_work_profile='work'
+        printf "Please input the name of the work profile[%s]:\n" "$default_work_profile"
+        read -r work_profile
+        work_profile=${work_profile:-$default_work_profile}
 
         printf "Enable macchanger to randomise MAC-address upon each connection? [Y/n]: "
         read -r mac_enable
@@ -48,7 +48,7 @@ setup() {
         profiles=""
         # Grab other profiles and concatenate in string, using comma as delimiter
         for entry in "/etc/netctl"/*; do
-            if [ -f "$entry" ] && [[ ! "$entry" =~ ^$profile_input$ ]] ; then
+            if [ -f "$entry" ] && [[ ! "$entry" =~ ^$work_profile$ ]] ; then
                 profiles+=$(echo "$(basename $entry)")','
             fi
         done

--- a/setup.sh
+++ b/setup.sh
@@ -23,10 +23,10 @@ setup() {
         printf "Please input password:\n"
         read -r -s password
 
-        default_work_profile='work'
-        printf "Please input name of work profile[%s]:\n" "$default_work_profile"
-        read -r work_profile
-        work_profile=${work_profile:-$default_work_profile}
+        default_profile='work'
+        printf "Please input name of work profile[%s]:\n" "$default_profile"
+        read -r profile_input
+        profile_input=${profile_input:-$default_profile}
 
         printf "Enable macchanger to randomise MAC-address upon each connection? [Y/n]: "
         read -r mac_enable
@@ -48,7 +48,7 @@ setup() {
         profiles=""
         # Grab other profiles and concatenate in string, using comma as delimiter
         for entry in "/etc/netctl"/*; do
-            if [ -f "$entry" ] && [[ ! "$entry" =~ ^$work_profile$ ]] ; then
+            if [ -f "$entry" ] && [[ ! "$entry" =~ ^$profile_input$ ]] ; then
                 profiles+=$(echo "$(basename $entry)")','
             fi
         done

--- a/setup.sh
+++ b/setup.sh
@@ -42,7 +42,7 @@ setup() {
         profiles=""
         # Grab other profiles and concatenate in string, using comma as delimiter
         for entry in "/etc/netctl"/*; do
-            if [ -f "$entry" ] && [[ ! "$entry" =~ work ]] ; then
+            if [ -f "$entry" ] && [[ ! "$entry" =~ ^work$ ]] ; then
                 profiles+=$(echo "$(basename $entry)")','
             fi
         done

--- a/setup.sh
+++ b/setup.sh
@@ -42,7 +42,7 @@ setup() {
         profiles=""
         # Grab other profiles and concatenate in string, using comma as delimiter
         for entry in "/etc/netctl"/*; do
-            if [ -f "$entry" ]; then
+            if [ -f "$entry" ] && [[ ! "$entry" =~ work ]] ; then
                 profiles+=$(echo "$(basename $entry)")','
             fi
         done


### PR DESCRIPTION
- Removed necessity for `[-p|profile]` argument, such that connecting to any profile under `netctl` conforms to the `chwifi <PROFILE>` syntax. However a different solution than proposed, this resolves #34 in all aspects.
- Updated `[-h|--help]` text to reflect that `chwifi` can be used to connect to any profile, and removed `[-p|profile]` argument text.
- Updated README to reflect the changes made.
- Excluded `work` profile from other profiles configuration.