### PR TITLE
Remove update arg and update network wait error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Connect to any netctl wireless networks, caching rolling passwords at work
 Optional arguments:
   -s, show [index|today|tomorrow]	display the daily password of the given index or day
   -r, restart [profile]			restarts the given profile
-  -u, update				update profiles under netctl
   -h, --help				display this help and exit
 
 chwifi is released under GPL-2.0 and comes with ABSOLUTELY NO WARRANTY, for details read LICENSE
@@ -72,12 +71,6 @@ To restart a given profile, pass either `-r` or `restart` followed by the profil
 ```shell
 chwifi -r home
 chwifi restart work
-```
-
-To update recognised profiles, pass either `-u` or `update`. This should be done whenever a profile is added or removed.
-```shell
-chwifi -u
-chwifi update
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ sudo="sudo"
 Example shows chwifi call, with work keyword, printing cached password if foun, and username used for updating cached passwords.
 ```
 user@hostname ~> chwifi work
-Work-keyword found, checking for cached password
+Updating recognised netctl profiles...
+Connecting to work, checking for cached password
 Daily work password is: amount42wind
 Stopping all profiles
 New MAC-address: 00:1a:e9:cb:55:ef 

--- a/chwifi
+++ b/chwifi
@@ -235,7 +235,7 @@ while (( "$#" )); do
             exit 0
             ;;
         *)
-            # If an unrecognized argument is given, check if it is a recognized netctl profile
+            # If an unrecognised argument is given, check if it is a recognised netctl profile
             if check_profile "$1" ; then
                 profile=$1
             else

--- a/chwifi
+++ b/chwifi
@@ -68,7 +68,7 @@ wait_for_network() {
     adapter_status=$(ip address show "$wireless_adapter")
     # If adapter status is down at this point, connection failed
     if [[ "$adapter_status" =~ "DOWN" ]] ; then
-        printf "Could not connect, please ensure that the network adapter, '%s', is available.\n" "$wireless_adapter"
+        printf "Could not connect, please ensure that the network is available.\n"
         exit 1
     fi
     connection_start_time=$(date +%s.%N)

--- a/chwifi
+++ b/chwifi
@@ -92,7 +92,7 @@ update_routine() {
 }
 
 update_profiles() {
-    printf '%s\n' "Updating recognised netctl profiles profiles..."
+    printf '%s\n' "Updating recognised netctl profiles..."
     config=$(config_dir)
     profiles=""
     # Grab other profiles and concatenate in string, using comma as delimiter

--- a/chwifi
+++ b/chwifi
@@ -92,7 +92,7 @@ update_routine() {
 }
 
 update_profiles() {
-    printf '%s\n' "Updating profiles..."
+    printf '%s\n' "Updating recognised netctl profiles profiles..."
     config=$(config_dir)
     profiles=""
     # Grab other profiles and concatenate in string, using comma as delimiter
@@ -175,7 +175,6 @@ display_help() {
     printf "Optional arguments:\n"
     printf "  -s, show [index|today|tomorrow]\tdisplay the daily password of the given index or day\n"
     printf "  -r, restart [profile]\t\t\trestarts the given profile\n"
-    printf "  -u, update\t\t\t\tupdate profiles under netctl\n"
     printf "  -h, --help\t\t\t\tdisplay this help and exit\n\n"
     printf "chwifi is released under GPL-2.0 and comes with ABSOLUTELY NO WARRANTY, for details read LICENSE\n"
     printf "Configuration of this script is done through the 'config' file, for documentation read README.md\n"
@@ -183,6 +182,9 @@ display_help() {
 
 # Save arguments
 args=$*
+
+# Update recognised netctl profiles
+update_profiles
 
 # Parse all arguments
 while (( "$#" )); do
@@ -231,11 +233,6 @@ while (( "$#" )); do
             # Print help and exit
             display_help
             exit 0
-            ;;
-        -u|update)
-            # Update other profiles
-            update_profiles
-            break
             ;;
         *)
             # If an unrecognized argument is given, check if it is a recognized netctl profile


### PR DESCRIPTION
- The update routine for recognised profiles is now run before arguments is parsed, and the `[-u|update]` argument has been removed. 
- Changed the error message in `wait_for_network` to properly reflect the origin of the error.
- Removed `[-u|update]` argument from README.